### PR TITLE
fixup for moniwiki 1.2.5

### DIFF
--- a/wikistat/engines/moniwiki.py
+++ b/wikistat/engines/moniwiki.py
@@ -23,7 +23,9 @@ def collect(options):
     # remove bullet syntax
     prefix = re.sub(r'^\*', '', prefix.lstrip()).lstrip()
     resp = http_get(options['rc_url'])
-    match = re.search(re.escape(prefix) + '(\d+)', resp.text)
+    # strip html tags
+    body = re.sub(r'<[^>]+>', '', resp.text);
+    match = re.search(re.escape(prefix) + '(\d+)', body)
     data['page_count'] = int(match.group(1))
     resp = http_get(options['rc_url'], params={'action': 'atom', 'c': '100'})
     d = feedparser.parse(resp.text)


### PR DESCRIPTION
모니위키 1.2.5에서 고친 부분때문에 리그베다위키/스레디키가 작동하지 않고있네요.
PageCount 매크로를 감싸고 있는 `<span class='macro'>` 태그때문입니다.

간단히 tag를 strip하게끔 고쳤습니다.