### PR TITLE
Fix gooswiki

### DIFF
--- a/sites.yml
+++ b/sites.yml
@@ -45,10 +45,10 @@ engine_options:
 id: gooswiki
 name: 구스위키
 license: CC-by-nc-sa 3.0
-url: "http://gooswiki.com/"
+url: "http://goos.wiki/"
 engine: mediawiki
 engine_options:
-  api_endpoint: "http://gooswiki.com/api.php"
+  api_endpoint: "http://goos.wiki/api.php"
 
 ---
 id: rigvedawiki


### PR DESCRIPTION
구스위키 도메인 바뀌고 예전 도메인 갱신을 안 해서 만료됐다고 합니다